### PR TITLE
Extend converter to process multiple files

### DIFF
--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -101,10 +101,12 @@ def main() -> int:
         columns={RUNTIME_OR_FAILURE_COLUMN_NAME: column_names_filenames[0][0]},
         inplace=True,
     )
+    final_dataframe.sort_values(by=COMPILATION_UNIT_COLUMN_NAME, inplace=True, ignore_index=True)
 
     # Add the last column of the rest of the tables to the final dataframe.
     for column_name, filename in column_names_filenames[1:]:
         dataframe = pandas.read_csv(filename, sep=arguments.field_separator)
+        dataframe.sort_values(by=COMPILATION_UNIT_COLUMN_NAME, inplace=True, ignore_index=True)
         if not (
             final_dataframe.loc[:, COMPILATION_UNIT_COLUMN_NAME].equals(
                 dataframe.loc[:, COMPILATION_UNIT_COLUMN_NAME]

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -117,9 +117,7 @@ def main() -> int:
             dataframe.loc[:, "Runtime or failure"],
         )
 
-    # NOTE(Brent): For now leave this call commented-out since it makes
-    # assumptions about the input's column headers.
-    # dataframe = add_total_passing(dataframe)
+    final_dataframe = add_total_passing(final_dataframe)
 
     markdown = final_dataframe.to_markdown(index=False)
     if markdown is None:

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -18,10 +18,9 @@ from typing import Optional
 
 
 class Arguments(argparse.Namespace):
-    """
-    Program arguments"""
+    """Program arguments"""
 
-    input_filepath: pathlib.Path
+    column_filename_json: str
     output_filepath: Optional[pathlib.Path]
     field_separator: str
 
@@ -41,7 +40,11 @@ vast-front failed to process the file.
 The names of the files in the first column must match in all input files""".lstrip()
     )
 
-    parser.add_argument("input_filepath", type=pathlib.Path, help="Input filepath.")
+    parser.add_argument(
+        "column_filename_json",
+        type=str,
+        help="A JSON object mapping column names to the names of the files containing their data.",
+    )
     parser.add_argument(
         "--output_filepath",
         "-o",

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -9,9 +9,11 @@ vast-front, in seconds, to run on the file; or the string literal FAIL if
 vast-front failed to process the file.
 """
 
-import pathlib
-import pandas
 import argparse
+import json
+import pandas
+import pathlib
+import sys
 from typing import Optional
 
 

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -69,11 +69,14 @@ def add_total_passing(dataframe: pandas.DataFrame) -> pandas.DataFrame:
     Counts the number of rows with passing results and adds a row listing this
     number to the given dataframe.
     """
-    ...
-    passing = sum(dataframe["Runtime or failure"] != "FAIL")
-    total = dataframe.index.size
-    ratio = f"{passing}/{total}"
-    totals_row = pandas.DataFrame([["Total passing", ratio]], columns=dataframe.columns)
+
+    totals = ["Total passing"]
+    for i in range(1, len(dataframe.columns)):
+        passing = sum(dataframe.iloc[:, i] != "FAIL")
+        total = len(dataframe)
+        ratio = f"{passing}/{total}"
+        totals.append(ratio)
+    totals_row = pandas.DataFrame([totals], columns=dataframe.columns)
     # See https://stackoverflow.com/a/67678982/6824430
     return pandas.concat([totals_row, dataframe], ignore_index=True)
 

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -88,7 +88,8 @@ def main() -> int:
 
     markdown = dataframe.to_markdown(index=False)
     if markdown is None:
-        raise ValueError("error: could not convert input to markdown")
+        print("error: Could not convert input to Markdown", file=sys.stderr)
+        return 1
     if arguments.output_filepath is not None:
         with open(arguments.output_filepath, "w") as fp:
             fp.write(markdown)

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -49,7 +49,7 @@ The names of the files in the first column must match in all input files""".lstr
         "--output_filepath",
         "-o",
         type=pathlib.Path,
-        help="Output filepath (if omitted, result is printed to stderr).",
+        help="Output filepath (if omitted, result is printed to stdout).",
     )
     parser.add_argument(
         "-t",

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -9,6 +9,9 @@ vast-front, in seconds, to run on the file; or the string literal FAIL if
 vast-front failed to process the file.
 """
 
+COMPILATION_UNIT_COLUMN_NAME = "Compilation unit"
+RUNTIME_OR_FAILURE_COLUMN_NAME = "Runtime or failure"
+
 import argparse
 import json
 import pandas
@@ -94,16 +97,17 @@ def main() -> int:
     final_dataframe = pandas.read_csv(
         column_names_filenames[0][1], sep=arguments.field_separator
     )
-    final_dataframe = final_dataframe.rename(
-        columns={"Runtime or failure": column_names_filenames[0][0]}
+    final_dataframe.rename(
+        columns={RUNTIME_OR_FAILURE_COLUMN_NAME: column_names_filenames[0][0]},
+        inplace=True,
     )
 
     # Add the last column of the rest of the tables to the final dataframe.
     for column_name, filename in column_names_filenames[1:]:
         dataframe = pandas.read_csv(filename, sep=arguments.field_separator)
         if not (
-            final_dataframe.loc[:, "Compilation unit"].equals(
-                dataframe.loc[:, "Compilation unit"]
+            final_dataframe.loc[:, COMPILATION_UNIT_COLUMN_NAME].equals(
+                dataframe.loc[:, COMPILATION_UNIT_COLUMN_NAME]
             )
         ):
             print(
@@ -114,7 +118,7 @@ def main() -> int:
         final_dataframe.insert(
             len(final_dataframe.columns),
             column_name,
-            dataframe.loc[:, "Runtime or failure"],
+            dataframe.loc[:, RUNTIME_OR_FAILURE_COLUMN_NAME],
         )
 
     final_dataframe = add_total_passing(final_dataframe)

--- a/utils/to_markdown.py
+++ b/utils/to_markdown.py
@@ -1,5 +1,12 @@
 """
-Converts a series of field-separated values to a markdown table.
+Combines field-separated-values files containing VAST runtime data into one
+Markdown table.
+
+Each file is expected to have two columns: "Compilation unit" and "Runtime or
+failure". The first column is the name of the file VAST was run on. The second
+column is either a floating point number representing how long it took
+vast-front, in seconds, to run on the file; or the string literal FAIL if
+vast-front failed to process the file.
 """
 
 import pathlib
@@ -19,7 +26,17 @@ class Arguments(argparse.Namespace):
 
 def parse_args() -> Arguments:
     parser = argparse.ArgumentParser(
-        description="Converts a series of field-separated values to a markdown table"
+        description="""
+Combines field-separated-values files containing VAST runtime data into one
+Markdown table.
+
+Each file is expected to have two columns: "Compilation unit" and "Runtime or
+failure". The first column is the name of the file VAST was run on. The second
+column is either a floating point number representing how long it took
+vast-front, in seconds, to run on the file; or the string literal FAIL if
+vast-front failed to process the file.
+
+The names of the files in the first column must match in all input files""".lstrip()
     )
 
     parser.add_argument("input_filepath", type=pathlib.Path, help="Input filepath.")


### PR DESCRIPTION
Extends the markdown converter script to accept multiple files as input and combine them all into a single Markdown table.