### PR TITLE
Simplify linux kernel time output

### DIFF
--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -217,6 +217,7 @@ def run_vast_on_compile_commands(
     vast_path: pathlib.Path,
     vast_option: list[str],
     compile_commands: list[CompileCommand],
+    linux_directory: pathlib.Path,
     output_directory: Optional[pathlib.Path],
     num_processes: int,
     print_commands: bool,
@@ -248,7 +249,7 @@ def run_vast_on_compile_commands(
             enumerate(pool.imap(run_vast_on_compile_command, vast_benchmark_inputs), 1),
             compile_commands,
         ):
-            filepath = compile_command.file
+            filepath = "." + compile_command.file.removeprefix(str(linux_directory))
             failed = isinstance(elapsed_or_error, str)
             num_passing += int(not failed)
             row = [filepath]
@@ -286,6 +287,9 @@ def main() -> int:
     compile_commands_file = arguments.compile_commands_file.absolute()
     compile_commands = load_compile_commands(compile_commands_file)
 
+    # Get the path to the Linux directory so we can remove it from the output.
+    linux_directory = compile_commands_file.parent
+
     output_directory = arguments.output_directory
     if output_directory is not None:
         output_directory = output_directory.absolute()
@@ -294,6 +298,7 @@ def main() -> int:
         vast_path=pathlib.Path(arguments.vast_path),
         vast_option=arguments.vast_option,
         compile_commands=compile_commands,
+        linux_directory=linux_directory,
         output_directory=output_directory,
         num_processes=arguments.num_processes,
         print_commands=arguments.print_commands,

--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -251,14 +251,17 @@ def run_vast_on_compile_commands(
             filepath = compile_command.file
             failed = isinstance(elapsed_or_error, str)
             num_passing += int(not failed)
-
-            row = [filepath, str(elapsed_or_error) if not failed else "FAIL"]
-            print_tsv_row(row)
-
+            row = [filepath]
             fraction = f"{i}/{len(compile_commands)}"
+
             if not failed:
+                seconds = elapsed_or_error.seconds
+                microseconds = str(elapsed_or_error.microseconds)[:2]
+                formatted_timedelta = f"{seconds}.{microseconds}"
+                row.append(formatted_timedelta)
                 print(f"finished processing {fraction} files", file=sys.stderr)
             else:
+                row.append("FAIL")
                 print(f"error processing {fraction} files", file=sys.stderr)
                 if print_errors:
                     print(elapsed_or_error, file=sys.stderr)
@@ -271,6 +274,8 @@ def run_vast_on_compile_commands(
                         log_filepath = log_filepath.with_name(log_name + "_")
                     with open(log_filepath, "w") as fp:
                         print(elapsed_or_error, file=fp)
+
+            print_tsv_row(row)
 
     return num_passing
 


### PR DESCRIPTION
Simplify the output of the Linux kernel benchmark script to use relative paths for filenames and list only the time and microseconds required for `vast-front` to process each file.