### PR TITLE
Use `gen_compile_commands.py` to generate Linux kernel compilation database

### DIFF
--- a/benchmarks/linux_kernel/linux_testing_guide.md
+++ b/benchmarks/linux_kernel/linux_testing_guide.md
@@ -13,7 +13,6 @@ Download the following dependencies using your own package manager:
 
 - [GNU Make](https://www.gnu.org/software/make/)
 - [Clang/LLVM/LLD 18.1.8](https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.8)
-- [Bear](https://github.com/rizsotto/Bear)
 - [Python3](https://www.python.org/downloads/)
 
 Download `VAST` from GitHub and follows its setup instructions:
@@ -35,18 +34,22 @@ cd linux/
 make defconfig
 ```
 
-1. Build the kernel and intercept its build system:
+1. Build the kernel:
 
 ```bash
 cd linux/
-bear -- make LLVM=1
+make LLVM=1
 ```
 
 Note that we use the `LLVM=1` flag to build the kernel with Clang-compatible
 arguments only and without any GCC-specific arguments.
 
-By this point the kernel should be built and a `compile_commands.json` file
-should exist in the kernel's top-level directory.
+1. Run the kernel's `gen_compile_commands.py` script to generate a compilation
+   database of the the kernel's source files:
+
+```sh
+python3 `scripts/clang-tools/gen_compile_commands.py`
+```
 
 ## Running VAST on Linux
 

--- a/benchmarks/linux_kernel/linux_testing_guide.md
+++ b/benchmarks/linux_kernel/linux_testing_guide.md
@@ -23,33 +23,33 @@ Download `VAST` from GitHub and follows its setup instructions:
 
 1. Download the most recent version of the kernel:
 
-```bash
-git clone https://github.com/torvalds/linux.git --depth=1
-```
+    ```bash
+    git clone https://github.com/torvalds/linux.git --depth=1
+    ```
 
 1. Configure the kernel with its default configuration:
 
-```bash
-cd linux/
-make defconfig
-```
+    ```bash
+    cd linux/
+    make defconfig
+    ```
 
 1. Build the kernel:
 
-```bash
-cd linux/
-make LLVM=1
-```
+    ```bash
+    cd linux/
+    make LLVM=1
+    ```
 
-Note that we use the `LLVM=1` flag to build the kernel with Clang-compatible
-arguments only and without any GCC-specific arguments.
+    Note that we use the `LLVM=1` flag to build the kernel with Clang-compatible
+    arguments only and without any GCC-specific arguments.
 
 1. Run the kernel's `gen_compile_commands.py` script to generate a compilation
    database of the the kernel's source files:
 
-```sh
-python3 `scripts/clang-tools/gen_compile_commands.py`
-```
+    ```sh
+    python3 `scripts/clang-tools/gen_compile_commands.py`
+    ```
 
 ## Running VAST on Linux
 

--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -104,7 +104,7 @@ class CompileCommand:
 
     directory: str
     file: str
-    output: str
+    output: Optional[str] = None
     arguments: Optional[list[str]] = None
     command: Optional[str] = None
 


### PR DESCRIPTION
Updates the documentation and benchmark script for evaluating the Linux kernel to work with the output of the kernel's `gen_compile_commands.py` script.