### PR TITLE
Improve Linux kernel benchmark robustness

### DIFF
--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -162,7 +162,7 @@ def run_vast_on_compile_command(
     # Turn this back into a dataclass since astuple() works recursively.
     compile_command = CompileCommand(*compile_command)
 
-    input_filepath = pathlib.PurePath(os.path.abspath(compile_command.file))
+    input_filepath = pathlib.PurePath(compile_command.file)
     input_mlir_name = input_filepath.with_suffix(".mlir").name
 
     output_filepath = pathlib.Path()

--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -179,6 +179,15 @@ def run_vast_on_compile_command(
         arg.replace("(", "\\(").replace(")", "\\)") for arg in original_arguments
     ]
 
+    # Escape single quotes in command-line macro definitions like
+    # -DFOO='"string"', because for some reason subprocess.run() does not handle
+    # them correctly and break the macro definition.
+    for i, arg in enumerate(escaped_arguments):
+        if "='\"" in arg:
+            escaped = arg.replace("='\"", '="\\"')
+            escaped = escaped[:-2] + '\\""'
+            escaped_arguments[i] = escaped
+
     # If the -cc1 flag was passed, move it to the front of the arguments list.
     has_cc1 = "-cc1" in escaped_arguments
     if has_cc1:

--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -315,6 +315,13 @@ def main() -> int:
     compile_commands_file = arguments.compile_commands_file.absolute()
     compile_commands = load_compile_commands(compile_commands_file)
 
+    # Filter the compile commands to only include .c files.
+    compile_commands = [
+        compile_command
+        for compile_command in compile_commands
+        if compile_command.file.endswith(".c")
+    ]
+
     # Get the path to the Linux directory so we can remove it from the output.
     linux_directory = compile_commands_file.parent
 

--- a/benchmarks/linux_kernel/run_vast_benchmark.py
+++ b/benchmarks/linux_kernel/run_vast_benchmark.py
@@ -214,7 +214,7 @@ def run_vast_on_compile_command(
             del escaped_arguments[i]
             break
 
-    command = " ".join(
+    command = (
         [str(vast_path)]
         + (["-cc1"] if has_cc1 else [])
         + vast_option
@@ -226,12 +226,11 @@ def run_vast_on_compile_command(
     )
 
     if print_commands:
-        print(command, file=sys.stderr)
+        print(" ".join(command), file=sys.stderr)
 
     begin = datetime.now()
     with subprocess.Popen(
         command,
-        shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=compile_command.directory,


### PR DESCRIPTION
Make the Linux kernel benchmark evaluation script more robust.

- Change the argument handling for the Linux kernel benchmark to correctly preserve command-line macro definitions.
  This change replaces single quotes and double quotes in macro definitions like `-DFOO-'"bar'"` to `-DFOO="\"bar\""`.
- Use `subprocess.Popen() and Popen.communicate()` to run shell commands, and pass a list of arguments instead of a raw shell command.
- Filter input compilation database so that `vast-front` only runs on its `.c` files.
- Find and remove input and output filenames from original compile commands instead of removing arguments at arbitrary positions which may or may not be the positions of these filenames.
- Use relative paths for filenames since we can't guarantee that the `file` and `output` fields of a given compile command will be an absolute path.